### PR TITLE
rm migrations dir and add wasp syntax on gh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.wasp linguist-language=TypeScript

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .wasp/
 node_modules/
+migrations/
 
 # Ignore all dotenv files by default to prevent accidentally committing any secrets.
 # To include specific dotenv files, use the `!` operator or adjust these rules.


### PR DESCRIPTION
- removes migrations dir from template (no need for users to start the template with these)
- adds syntax highlighting to .wasp files on github.com