### PR TITLE
fix: update CI to use npm-based Wasp 0.21 installer

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,9 +21,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Wasp
-        run: |
-          curl -sSL https://get.wasp.sh/installer.sh | sh
-          wasp compile
+        run: npm i -g @wasp.sh/wasp-cli@0.21
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The CI workflow uses pull_request_target which runs the workflow from main, not the PR branch. This means the Wasp install change in PR #53 can't take effect until main is updated. This tiny PR fixes that so #53's CI can pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD workflow by consolidating build setup steps for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->