### PR TITLE
fix: update CI to use npm wasp-cli instead of deprecated installer

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,9 +21,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Wasp
-        run: |
-          curl -sSL https://get.wasp.sh/installer.sh | sh
-          wasp compile
+        run: npm i -g @wasp.sh/wasp-cli@0.21
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The Wasp shell installer now requires a version flag and recommends using npm for 0.21+. This updates the format-and-lint workflow to use `npm i -g @wasp.sh/wasp-cli@0.21` instead of the curl installer.

This unblocks CI for all open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the development environment setup workflow by consolidating the tool installation process into a single, simplified step for faster and more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->